### PR TITLE
When the clear_list flag is false, instead of reseting the search lis…

### DIFF
--- a/lib/spare_keys.rb
+++ b/lib/spare_keys.rb
@@ -33,7 +33,7 @@ class SpareKeys
                     current_list = `security list-keychains #{domain_flag}`
                     current_list_as_array = current_list.scan(/"[^"]*"/).map { |item| item.gsub(/^"|"$/, "")}
                     # Remove the supplied keychain
-                    original_list = (current_list_as_array.reject { |item| item.include? keychain_path }).join(" ")
+                    original_list = (current_list_as_array.reject { |item| item == keychain_path }).join(" ")
                 end
                 
                 `security list-keychains #{domain_flag} -s #{original_list}`

--- a/lib/spare_keys.rb
+++ b/lib/spare_keys.rb
@@ -33,7 +33,7 @@ class SpareKeys
                     current_list = `security list-keychains #{domain_flag}`
                     current_list_as_array = current_list.scan(/"[^"]*"/).map { |item| item.gsub(/^"|"$/, "")}
                     # Remove the supplied keychain
-                    original_list = (current_list_as_array.reject { |item| File.basename(item) == keychain_path }).join(" ")
+                    original_list = (current_list_as_array.reject { |item| item.include? keychain_path }).join(" ")
                 end
                 
                 `security list-keychains #{domain_flag} -s #{original_list}`

--- a/lib/spare_keys.rb
+++ b/lib/spare_keys.rb
@@ -26,6 +26,15 @@ class SpareKeys
                 yield if block_given?
             ensure
                 original_keychain = `security #{type}-keychain #{domain_flag} -s #{original_keychain}` if type
+                
+                unless clear_list
+                    # Grab the keychain list as it looks right now in case
+                    # another process has changed it
+                    current_list = `security list-keychains #{domain_flag} | xargs`
+                    # Remove the supplied keychain
+                    original_list = (current_list.split(" ").reject { | item | item.include? keychain_path }).join(" ")
+                end
+                
                 `security list-keychains #{domain_flag} -s #{original_list}`
             end
         end

--- a/lib/spare_keys.rb
+++ b/lib/spare_keys.rb
@@ -33,7 +33,7 @@ class SpareKeys
                     current_list = `security list-keychains #{domain_flag}`
                     current_list_as_array = current_list.scan(/"[^"]*"/).map { |item| item.gsub(/^"|"$/, "")}
                     # Remove the supplied keychain
-                    original_list = (current_list_as_array.reject { |item| item == keychain_path }).join(" ")
+                    original_list = (current_list_as_array.reject { |item| File.basename(item) == keychain_path }).join(" ")
                 end
                 
                 `security list-keychains #{domain_flag} -s #{original_list}`

--- a/lib/spare_keys.rb
+++ b/lib/spare_keys.rb
@@ -30,9 +30,10 @@ class SpareKeys
                 unless clear_list
                     # Grab the keychain list as it looks right now in case
                     # another process has changed it
-                    current_list = `security list-keychains #{domain_flag} | xargs`
+                    current_list = `security list-keychains #{domain_flag}`
+                    current_list_as_array = current_list.scan(/"[^"]*"/).map { |item| item.gsub(/^"|"$/, "")}
                     # Remove the supplied keychain
-                    original_list = (current_list.split(" ").reject { | item | item.include? keychain_path }).join(" ")
+                    original_list = (current_list_as_array.reject { |item| item.include? keychain_path }).join(" ")
                 end
                 
                 `security list-keychains #{domain_flag} -s #{original_list}`

--- a/spec/spare_keys_spec.rb
+++ b/spec/spare_keys_spec.rb
@@ -85,6 +85,27 @@ describe SpareKeys, '#use_keychain' do
     end
   end
 
+  context "when clear_list is false" do
+    before do
+      @list_before_block = capture_keychain_list
+      @list_in_block = nil
+      
+      SpareKeys.use_keychain @example_keychain, false do
+        @list_in_block = capture_keychain_list
+      end
+      
+      @list_after_block = capture_keychain_list
+    end
+
+    it "should not remove other keychain entries for the duration of the block" do
+        expect(@list_in_block).to include("login.keychain")
+    end
+
+    it "should revert the keychain list after the block" do
+      expect(@list_after_block).to eql(@list_before_block)
+    end
+  end
+
   context "when type is specified" do
     before do
       @default_before_block = capture_keychain("default")


### PR DESCRIPTION
…t to whatever it was when use_keychain was called, the list is now reset to whatever it currently is, minus the supplied keychain.