### PR TITLE
Remove deprecated make_tmpname function

### DIFF
--- a/lib/spare_keys.rb
+++ b/lib/spare_keys.rb
@@ -57,9 +57,7 @@ class SpareKeys
         require 'securerandom'
 
         password = SecureRandom.hex
-
-        extension = keychain_extension()
-        temp_keychain = Dir::Tmpname.make_tmpname(['spare-keys-', extension], nil)
+        temp_keychain = temporary_keychain_name('spare-keys')
 
         `security create-keychain -p "#{password}" #{temp_keychain}`
         `security set-keychain-settings #{temp_keychain}`
@@ -105,6 +103,12 @@ private
         end
 
         return path
+    end
+
+    def self.temporary_keychain_name(prefix)
+        t = Time.now.strftime("%Y%m%d")
+        extension = keychain_extension()
+        "#{prefix}-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}#{extension}"
     end
 
 end

--- a/spec/spare_keys_spec.rb
+++ b/spec/spare_keys_spec.rb
@@ -4,7 +4,7 @@ describe SpareKeys, '#use_keychain' do
 
   before(:context) do
     require 'tempfile'
-    @example_keychain = Dir::Tmpname.make_tmpname(['spare-keys-spec-', SpareKeys.keychain_extension()], nil)
+    @example_keychain = SpareKeys.temporary_keychain_name('spare-keys-spec')
     `security create-keychain -p "" #{@example_keychain}`
   end
 


### PR DESCRIPTION
SpareKeys doesn't work with ruby 2.5+ due to a removed function -> Dir::Tmpname.make_tmpname

